### PR TITLE
refactor: 提取重复代码为独立 trait 和工具方法

### DIFF
--- a/src/Form/Field/Embeds.php
+++ b/src/Form/Field/Embeds.php
@@ -9,11 +9,11 @@ use Dcat\Admin\Form\ResolveField;
 use Dcat\Admin\Support\Helper;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Support\Str;
 
 class Embeds extends Field implements FieldsCollection
 {
     use ResolveField;
+    use HasFormatValidationAttribute;
 
     /**
      * @var \Closure
@@ -158,41 +158,6 @@ class Embeds extends Field implements FieldsCollection
         }
 
         return $result;
-    }
-
-    /**
-     * Format validation attributes.
-     *
-     * @param  array  $input
-     * @param  string  $label
-     * @param  string  $column
-     * @return array
-     */
-    protected function formatValidationAttribute($input, $label, $column)
-    {
-        $new = $attributes = [];
-
-        if (is_array($column)) {
-            foreach ($column as $index => $col) {
-                $new[$col.$index] = $col;
-            }
-        }
-
-        foreach (array_keys(Arr::dot($input)) as $key) {
-            if (is_string($column)) {
-                if (Str::endsWith($key, ".$column")) {
-                    $attributes[$key] = $label;
-                }
-            } else {
-                foreach ($new as $k => $val) {
-                    if (Str::endsWith($key, ".$k")) {
-                        $attributes[$key] = $label."[$val]";
-                    }
-                }
-            }
-        }
-
-        return $attributes;
     }
 
     /**

--- a/src/Form/Field/HasFormatValidationAttribute.php
+++ b/src/Form/Field/HasFormatValidationAttribute.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Dcat\Admin\Form\Field;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+trait HasFormatValidationAttribute
+{
+    /**
+     * Format validation attribute.
+     *
+     * @param  array  $input
+     * @param  string  $label
+     * @param  string|array  $column
+     * @return array
+     */
+    protected function formatValidationAttribute($input, $label, $column)
+    {
+        $new = $attributes = [];
+
+        if (is_array($column)) {
+            foreach ($column as $index => $col) {
+                $new[$col.$index] = $col;
+            }
+        }
+
+        foreach (array_keys(Arr::dot($input)) as $key) {
+            if (is_string($column)) {
+                if (Str::endsWith($key, ".$column")) {
+                    $attributes[$key] = $label;
+                }
+            } else {
+                foreach ($new as $k => $val) {
+                    if (Str::endsWith($key, ".$k")) {
+                        $attributes[$key] = $label."[$val]";
+                    }
+                }
+            }
+        }
+
+        return $attributes;
+    }
+}

--- a/src/Form/Field/HasMany.php
+++ b/src/Form/Field/HasMany.php
@@ -8,7 +8,6 @@ use Dcat\Admin\Form\NestedForm;
 use Dcat\Admin\Support\Helper;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Support\Str;
 
 /**
  * Class HasMany.
@@ -16,6 +15,7 @@ use Illuminate\Support\Str;
 class HasMany extends Field
 {
     use Form\ResolveField;
+    use HasFormatValidationAttribute;
 
     /**
      * Relation name.
@@ -245,41 +245,6 @@ class HasMany extends Field
         }
 
         return $result;
-    }
-
-    /**
-     * Format validation attributes.
-     *
-     * @param  array  $input
-     * @param  string  $label
-     * @param  string  $column
-     * @return array
-     */
-    protected function formatValidationAttribute($input, $label, $column)
-    {
-        $new = $attributes = [];
-
-        if (is_array($column)) {
-            foreach ($column as $index => $col) {
-                $new[$col.$index] = $col;
-            }
-        }
-
-        foreach (array_keys(Arr::dot($input)) as $key) {
-            if (is_string($column)) {
-                if (Str::endsWith($key, ".$column")) {
-                    $attributes[$key] = $label;
-                }
-            } else {
-                foreach ($new as $k => $val) {
-                    if (Str::endsWith($key, ".$k")) {
-                        $attributes[$key] = $label."[$val]";
-                    }
-                }
-            }
-        }
-
-        return $attributes;
     }
 
     /**

--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -2,16 +2,14 @@
 
 namespace Dcat\Admin\Form\Field;
 
-use Dcat\Admin\Exception\RuntimeException;
 use Dcat\Admin\Form\Field;
-use Dcat\Admin\Support\Helper;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Arr;
+use Dcat\Admin\Traits\HasModelOptions;
 
 class Select extends Field
 {
     use CanCascadeFields;
     use CanLoadFields;
+    use HasModelOptions;
     use Sizeable;
 
     protected $cascadeEvent = 'change';
@@ -79,45 +77,6 @@ class Select extends Field
     public function groups(array $groups)
     {
         $this->groups = $groups;
-
-        return $this;
-    }
-
-    /**
-     * Load options from current selected resource(s).
-     *
-     * @param  string  $model
-     * @param  string  $idField
-     * @param  string  $textField
-     * @return $this
-     */
-    public function model($model, string $idField = 'id', string $textField = 'name')
-    {
-        if (! class_exists($model)
-            || ! in_array(Model::class, class_parents($model))
-        ) {
-            throw new RuntimeException("[$model] must be a valid model class");
-        }
-
-        $this->options = function ($value) use ($model, $idField, $textField) {
-            if (empty($value)) {
-                return [];
-            }
-
-            $resources = [];
-
-            if (is_array($value)) {
-                if (Arr::isAssoc($value)) {
-                    $resources[] = Arr::get($value, $idField);
-                } else {
-                    $resources = array_column($value, $idField);
-                }
-            } else {
-                $resources[] = $value;
-            }
-
-            return $model::whereIn($idField, $resources)->pluck($textField, $idField)->toArray();
-        };
 
         return $this;
     }

--- a/src/Grid/Filter/Presenter/Select.php
+++ b/src/Grid/Filter/Presenter/Select.php
@@ -2,14 +2,11 @@
 
 namespace Dcat\Admin\Grid\Filter\Presenter;
 
-use Dcat\Admin\Exception\RuntimeException;
-use Dcat\Admin\Support\Helper;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Arr;
+use Dcat\Admin\Traits\HasModelOptions;
 
 class Select extends Presenter
 {
+    use HasModelOptions;
     /**
      * @var string
      */
@@ -122,45 +119,6 @@ class Select extends Presenter
         ]);
 
         return is_array($this->options) ? $this->options : [];
-    }
-
-    /**
-     * Load options from current selected resource(s).
-     *
-     * @param  string  $model
-     * @param  string  $idField
-     * @param  string  $textField
-     * @return $this
-     */
-    public function model($model, string $idField = 'id', string $textField = 'name')
-    {
-        if (! class_exists($model)
-            || ! in_array(Model::class, class_parents($model))
-        ) {
-            throw new RuntimeException("[$model] must be a valid model class");
-        }
-
-        $this->options = function ($value) use ($model, $idField, $textField) {
-            if (empty($value)) {
-                return [];
-            }
-
-            $resources = [];
-
-            if (is_array($value)) {
-                if (Arr::isAssoc($value)) {
-                    $resources[] = Arr::get($value, $idField);
-                } else {
-                    $resources = array_column($value, $idField);
-                }
-            } else {
-                $resources[] = $value;
-            }
-
-            return $model::find($resources)->pluck($textField, $idField)->toArray();
-        };
-
-        return $this;
     }
 
     /**

--- a/src/Http/Controllers/HasMenuTreeField.php
+++ b/src/Http/Controllers/HasMenuTreeField.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Dcat\Admin\Http\Controllers;
+
+use Dcat\Admin\Form;
+
+trait HasMenuTreeField
+{
+    /**
+     * Add menu tree field to form.
+     */
+    protected function addMenuTreeField(Form $form)
+    {
+        $form->tree('menus', trans('admin.menu'))
+            ->treeState(false)
+            ->setTitleColumn('title')
+            ->nodes(function () {
+                $model = config('admin.database.menu_model');
+
+                return (new $model())->allNodes();
+            })
+            ->customFormat(function ($v) {
+                if (! $v) {
+                    return [];
+                }
+
+                return array_column($v, 'id');
+            });
+    }
+
+    /**
+     * Flush menu cache after form saved.
+     */
+    protected function flushMenuCache()
+    {
+        $model = config('admin.database.menu_model');
+        (new $model())->flushCache();
+    }
+}

--- a/src/Http/Controllers/PermissionController.php
+++ b/src/Http/Controllers/PermissionController.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Str;
 
 class PermissionController extends AdminController
 {
+    use HasMenuTreeField;
     protected function title()
     {
         return trans('admin.permissions');
@@ -116,21 +117,7 @@ class PermissionController extends AdminController
                 ->options($this->getRoutes());
 
             if ($bindMenu) {
-                $form->tree('menus', trans('admin.menu'))
-                    ->treeState(false)
-                    ->setTitleColumn('title')
-                    ->nodes(function () {
-                        $model = config('admin.database.menu_model');
-
-                        return (new $model())->allNodes();
-                    })
-                    ->customFormat(function ($v) {
-                        if (! $v) {
-                            return [];
-                        }
-
-                        return array_column($v, 'id');
-                    });
+                $this->addMenuTreeField($form);
             }
 
             $form->display('created_at', trans('admin.created_at'));
@@ -139,8 +126,7 @@ class PermissionController extends AdminController
             $form->disableViewButton();
             $form->disableViewCheck();
         })->saved(function () {
-            $model = config('admin.database.menu_model');
-            (new $model())->flushCache();
+            $this->flushMenuCache();
         });
     }
 

--- a/src/Http/Controllers/RoleController.php
+++ b/src/Http/Controllers/RoleController.php
@@ -12,6 +12,7 @@ use Dcat\Admin\Widgets\Tree;
 
 class RoleController extends AdminController
 {
+    use HasMenuTreeField;
     public function title()
     {
         return trans('admin.roles');
@@ -113,21 +114,7 @@ class RoleController extends AdminController
                 });
 
             if ($bindMenu) {
-                $form->tree('menus', trans('admin.menu'))
-                    ->treeState(false)
-                    ->setTitleColumn('title')
-                    ->nodes(function () {
-                        $model = config('admin.database.menu_model');
-
-                        return (new $model())->allNodes();
-                    })
-                    ->customFormat(function ($v) {
-                        if (! $v) {
-                            return [];
-                        }
-
-                        return array_column($v, 'id');
-                    });
+                $this->addMenuTreeField($form);
             }
 
             $form->display('created_at', trans('admin.created_at'));
@@ -139,8 +126,7 @@ class RoleController extends AdminController
                 $form->disableDeleteButton();
             }
         })->saved(function () {
-            $model = config('admin.database.menu_model');
-            (new $model())->flushCache();
+            $this->flushMenuCache();
         });
     }
 

--- a/src/Http/Middleware/Authenticate.php
+++ b/src/Http/Middleware/Authenticate.php
@@ -42,22 +42,6 @@ class Authenticate
             Admin::context()->getArray('auth.except')
         );
 
-        foreach ($excepts as $except) {
-            if ($request->routeIs($except) || $request->routeIs(admin_route_name($except))) {
-                return true;
-            }
-
-            $except = admin_base_path($except);
-
-            if ($except !== '/') {
-                $except = trim($except, '/');
-            }
-
-            if (Helper::matchRequestPath($except)) {
-                return true;
-            }
-        }
-
-        return false;
+        return Helper::shouldPassThrough($request, $excepts);
     }
 }

--- a/src/Http/Middleware/Permission.php
+++ b/src/Http/Middleware/Permission.php
@@ -93,31 +93,20 @@ class Permission
      */
     public function shouldPassThrough($request)
     {
-        if ($this->isApiRoute($request) || Authenticate::shouldPassThrough($request)) {
+        if ($this->isApiRoute($request)) {
             return true;
         }
 
-        $excepts = array_merge(
+        $authExcept = array_merge(
+            (array) config('admin.auth.except', []),
+            Admin::context()->getArray('auth.except')
+        );
+
+        $permissionExcept = array_merge(
             (array) config('admin.permission.except', []),
             Admin::context()->getArray('permission.except')
         );
 
-        foreach ($excepts as $except) {
-            if ($request->routeIs($except) || $request->routeIs(admin_route_name($except))) {
-                return true;
-            }
-
-            $except = admin_base_path($except);
-
-            if ($except !== '/') {
-                $except = trim($except, '/');
-            }
-
-            if (Helper::matchRequestPath($except)) {
-                return true;
-            }
-        }
-
-        return false;
+        return Helper::shouldPassThrough($request, [...$authExcept, ...$permissionExcept]);
     }
 }

--- a/src/Support/Helper.php
+++ b/src/Support/Helper.php
@@ -286,6 +286,34 @@ class Helper
     }
 
     /**
+     * Determine if the request should pass through based on except patterns.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  array  $excepts
+     * @return bool
+     */
+    public static function shouldPassThrough($request, array $excepts)
+    {
+        foreach ($excepts as $except) {
+            if ($request->routeIs($except) || $request->routeIs(admin_route_name($except))) {
+                return true;
+            }
+
+            $except = admin_base_path($except);
+
+            if ($except !== '/') {
+                $except = trim($except, '/');
+            }
+
+            if (static::matchRequestPath($except)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * 生成层级数据.
      *
      * @param  array  $nodes

--- a/src/Traits/HasModelOptions.php
+++ b/src/Traits/HasModelOptions.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Dcat\Admin\Traits;
+
+use Dcat\Admin\Exception\RuntimeException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
+
+trait HasModelOptions
+{
+    /**
+     * Load options from current selected resource(s).
+     *
+     * @param  string  $model
+     * @param  string  $idField
+     * @param  string  $textField
+     * @return $this
+     */
+    public function model($model, string $idField = 'id', string $textField = 'name')
+    {
+        if (! class_exists($model)
+            || ! in_array(Model::class, class_parents($model))
+        ) {
+            throw new RuntimeException("[$model] must be a valid model class");
+        }
+
+        $this->options = function ($value) use ($model, $idField, $textField) {
+            if (empty($value)) {
+                return [];
+            }
+
+            $resources = [];
+
+            if (is_array($value)) {
+                if (Arr::isAssoc($value)) {
+                    $resources[] = Arr::get($value, $idField);
+                } else {
+                    $resources = array_column($value, $idField);
+                }
+            } else {
+                $resources[] = $value;
+            }
+
+            return $model::whereIn($idField, $resources)->pluck($textField, $idField)->toArray();
+        };
+
+        return $this;
+    }
+}

--- a/src/Traits/HasModelOptions.php
+++ b/src/Traits/HasModelOptions.php
@@ -41,6 +41,7 @@ trait HasModelOptions
                 $resources[] = $value;
             }
 
+            // 使用 whereIn 而非 find，以支持非主键字段（如 uuid、slug 等）
             return $model::whereIn($idField, $resources)->pluck($textField, $idField)->toArray();
         };
 


### PR DESCRIPTION
## Summary

- 提取中间件 `shouldPassThrough` 公共逻辑到 `Helper::shouldPassThrough()`，消除中间件间相互调用
- 提取 Select `model` 选项逻辑到 `HasModelOptions` trait
- 提取控制器菜单树字段逻辑到 `HasMenuTreeField` trait
- 提取验证属性格式化逻辑到 `HasFormatValidationAttribute` trait

## 行为变化说明

### Grid\Filter\Presenter\Select 的 `model()` 方法

**变更前**：使用 `$model::find($resources)` 按主键查找
**变更后**：使用 `$model::whereIn($idField, $resources)` 按指定字段查找

**影响**：
- 当 `$idField` 是主键（默认 'id'）时，行为完全一致
- 当 `$idField` 不是主键时，新实现更正确（按指定字段查找而非主键）
- 这是一个改进，使 Form\Field\Select 和 Grid\Filter\Presenter\Select 的行为统一且更通用

## 变更文件

| 新增 | 用途 |
|---|---|
| `src/Traits/HasModelOptions.php` | Select 模型选项通用逻辑 |
| `src/Http/Controllers/HasMenuTreeField.php` | 控制器菜单树字段通用逻辑 |
| `src/Form/Field/HasFormatValidationAttribute.php` | 验证属性格式化通用逻辑 |

| 修改 | 变更 |
|---|---|
| `src/Support/Helper.php` | 新增 `shouldPassThrough()` 方法 |
| `src/Http/Middleware/Authenticate.php` | 调用 Helper，移除重复循环 |
| `src/Http/Middleware/Permission.php` | 直接调用 Helper，与 Authenticate 零耦合 |
| `src/Form/Field/Select.php` | 使用 HasModelOptions trait |
| `src/Grid/Filter/Presenter/Select.php` | 使用 HasModelOptions trait |
| `src/Form/Field/HasMany.php` | 使用 HasFormatValidationAttribute trait |
| `src/Form/Field/Embeds.php` | 使用 HasFormatValidationAttribute trait |
| `src/Http/Controllers/RoleController.php` | 使用 HasMenuTreeField trait |
| `src/Http/Controllers/PermissionController.php` | 使用 HasMenuTreeField trait |

## 设计原则

- 高内聚低耦合：中间件之间零依赖，都通过 Helper 工具层通信
- 每个 trait 职责单一，只封装一类重复逻辑
- 清理了移除重复代码后不再使用的 import

## Test plan

- [ ] 验证后台登录/登出流程正常
- [ ] 验证权限中间件对路由的放行/拦截逻辑不变
- [ ] 验证 Role/Permission 表单中菜单树字段正常渲染和保存
- [ ] 验证 Select 字段的 model() 方法正常加载选项
- [ ] 验证 HasMany/Embeds 字段的验证错误提示属性格式正确
- [ ] 验证 Grid Filter 的 Select 字段 model() 方法正常工作