### PR TITLE
fix: 修复安全漏洞并清理死代码

### DIFF
--- a/src/Http/Controllers/HandleActionController.php
+++ b/src/Http/Controllers/HandleActionController.php
@@ -42,7 +42,7 @@ class HandleActionController
 
         $actionClass = str_replace('_', '\\', $request->get('_action'));
 
-        if (! class_exists($actionClass)) {
+        if (! class_exists($actionClass) || ! is_subclass_of($actionClass, Action::class)) {
             throw new AdminException("Action [{$actionClass}] does not exist.");
         }
 

--- a/src/Http/Controllers/RenderableController.php
+++ b/src/Http/Controllers/RenderableController.php
@@ -51,6 +51,10 @@ class RenderableController
 
         $class = str_replace('_', '\\', $class);
 
+        if (! class_exists($class) || ! is_subclass_of($class, LazyRenderable::class)) {
+            throw new \InvalidArgumentException("Renderable [{$class}] does not exist or does not implement LazyRenderable.");
+        }
+
         $renderable = new $class();
 
         $renderable->payload($request->all());

--- a/src/Http/Controllers/TinymceController.php
+++ b/src/Http/Controllers/TinymceController.php
@@ -12,7 +12,7 @@ class TinymceController
     public function upload(Request $request)
     {
         $file = $request->file('file');
-        $dir = trim($request->get('dir'), '/');
+        $dir = $this->sanitizeDir($request->get('dir'));
         $disk = $this->disk();
 
         $newName = $this->generateNewName($file);
@@ -28,11 +28,32 @@ class TinymceController
     }
 
     /**
+     * Sanitize directory path to prevent path traversal.
+     */
+    protected function sanitizeDir(?string $dir): string
+    {
+        $dir = trim($dir ?? '', '/');
+
+        // 移除路径遍历字符
+        $dir = str_replace(['../', '..\\', '..'], '', $dir);
+
+        // 确保路径不以点开头（隐藏文件）
+        $dir = ltrim($dir, '.');
+
+        return $dir ?: 'uploads';
+    }
+
+    /**
      * @return \Illuminate\Contracts\Filesystem\Filesystem|FilesystemAdapter
      */
     protected function disk()
     {
         $disk = request()->get('disk') ?: config('admin.upload.disk');
+
+        // 验证磁盘配置存在
+        if (! config("filesystems.disks.{$disk}")) {
+            $disk = config('admin.upload.disk', 'local');
+        }
 
         return Storage::disk($disk);
     }

--- a/src/Repositories/EloquentRepository.php
+++ b/src/Repositories/EloquentRepository.php
@@ -872,9 +872,8 @@ class EloquentRepository extends Repository implements TreeRepository
                     $parent->save();
 
                     // When in creating, associate two models
-                    $foreignKeyMethod = version_compare(app()->version(), '5.8.0', '<') ? 'getForeignKey' : 'getForeignKeyName';
-                    if (! $model->{$relation->{$foreignKeyMethod}()}) {
-                        $model->{$relation->{$foreignKeyMethod}()} = $parent->getKey();
+                    if (! $model->{$relation->getForeignKeyName()}) {
+                        $model->{$relation->getForeignKeyName()} = $parent->getKey();
 
                         $model->save();
                     }


### PR DESCRIPTION
## Summary

- **安全修复**：修复 3 个安全漏洞
  - HandleActionController: 添加 `is_subclass_of` 校验，防止任意类实例化
  - RenderableController: 添加 `LazyRenderable` 接口校验，防止任意类实例化
  - TinymceController: 添加路径遍历防护和磁盘白名单校验
- **代码清理**：移除 Laravel 5.8 兼容死代码

## 变更文件

| 文件 | 变更 |
|---|---|
| `src/Http/Controllers/HandleActionController.php` | 添加 Action 类校验 |
| `src/Http/Controllers/RenderableController.php` | 添加 LazyRenderable 接口校验 |
| `src/Http/Controllers/TinymceController.php` | 添加路径遍历防护和磁盘验证 |
| `src/Repositories/EloquentRepository.php` | 移除 Laravel 5.8 兼容代码 |

## 安全详情

### 任意类实例化漏洞
**风险**：攻击者可通过 `_action` 或 `renderable` 参数实例化服务器上的任意类，可能执行恶意代码。

**修复**：
- HandleActionController: 验证类必须继承 `Dcat\Admin\Actions\Action`
- RenderableController: 验证类必须实现 `Dcat\Admin\Contracts\LazyRenderable`

### 路径遍历漏洞
**风险**：攻击者可通过 `dir` 参数访问服务器上的任意目录，通过 `disk` 参数访问任意存储磁盘。

**修复**：
- 移除路径遍历字符（`../`、`..\\`、`..`）
- 验证磁盘配置存在，不存在时回退到默认磁盘

## Test plan

- [ ] 验证 Action 类正常执行
- [ ] 验证非法 Action 类被拒绝
- [ ] 验证 LazyRenderable 正常加载
- [ ] 验证非法 Renderable 类被拒绝
- [ ] 验证 TinyMCE 文件上传功能正常
- [ ] 验证路径遍历攻击被阻止
- [ ] 验证 BelongsTo 关系保存功能正常