### PR TITLE
fix: Octane 主题 CSS 路径重复、Select Helper 导入缺失及 PHP 8.4 兼容

### DIFF
--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -3,6 +3,7 @@
 namespace Dcat\Admin\Form\Field;
 
 use Dcat\Admin\Form\Field;
+use Dcat\Admin\Support\Helper;
 use Dcat\Admin\Traits\HasModelOptions;
 
 class Select extends Field

--- a/src/Grid/Displayers/HighlightJS.php
+++ b/src/Grid/Displayers/HighlightJS.php
@@ -28,7 +28,7 @@ class HighlightJS extends AbstractDisplayer
      * @return void
      */
     public
-    static function setResource(array|string $js = null, array|string $css = null): void
+    static function setResource(array|string|null $js = null, array|string|null $css = null): void
     {
         if ($js !== null) {
             static::$js = is_array($js) ? $js : [$js];

--- a/src/Layout/Asset.php
+++ b/src/Layout/Asset.php
@@ -281,6 +281,10 @@ class Asset
             $this->alias[$n]['css'] = [];
 
             foreach ($before as $css) {
+                if (str_contains($css, "-{$color}.css")) {
+                    $this->alias[$n]['css'][] = $css;
+                    continue;
+                }
                 $this->alias[$n]['css'][] = str_replace('.css', "-{$color}.css", $css);
             }
         }


### PR DESCRIPTION
## 修复内容

- **#17** 修复 FrankenPHP/Octane 持久进程下主题 CSS 路径重复追加颜色后缀（`adminlte-orange` → `adminlte-orange-orange`）
- **#18** 修复 `Select` 字段缺少 `Dcat\Admin\Support\Helper` 导入导致的类找不到错误
- 修复 `HighlightJS::setResource()` PHP 8.4 隐式可空参数废弃警告

Fixes #17
Fixes #18