### PR TITLE
feat: 兼容 Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require-dev": {
         "laravel/dusk": "^8.3",
         "phpstan/phpstan": "^2.1",
-        "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
+        "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0 || ^13.0",
         "fakerphp/faker": "^1.24",
         "mockery/mockery": "^1.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "printnow/laravel-admin",
-    "description": "Dcat admin 永久分叉版 / 支持 Laravel 12, PHP 版本限制 >= 8.1（支持 PHP 8.4）",
+    "description": "Dcat admin 永久分叉版 / 支持 Laravel 10-13, PHP 版本限制 >= 8.1（支持 PHP 8.5）",
     "type": "library",
     "keywords": [
         "dcat",
@@ -25,9 +25,8 @@
     ],
     "require": {
         "php": ">=8.1",
-        "laravel/framework": "~10.0|~11.0|~12.0",
-        "spatie/eloquent-sortable": "4.*",
-        "doctrine/dbal": "~3.0|~4.0",
+        "laravel/framework": "~10.0|~11.0|~12.0|~13.0",
+        "spatie/eloquent-sortable": "^4.0|^5.0",
         "ext-dom": "*",
         "ext-fileinfo": "*",
         "ext-zip": "*",

--- a/src/Console/ExportSeedCommand.php
+++ b/src/Console/ExportSeedCommand.php
@@ -32,7 +32,7 @@ class ExportSeedCommand extends Command
         $exceptFields = [];
         $exportUsers = $this->option('users');
 
-        $namespace = version_compare(app()->version(), '8.0.0', '<') ? 'seeds' : 'seeders';
+        $namespace = 'seeders';
 
         $seedFile = $this->laravel->databasePath().'/'.$namespace.'/'.$name.'.php';
         $contents = $this->getStub('AdminTablesSeeder');

--- a/src/Repositories/EloquentRepository.php
+++ b/src/Repositories/EloquentRepository.php
@@ -324,11 +324,9 @@ class EloquentRepository extends Repository implements TreeRepository
         $relatedTable = $relation->getRelated()->getTable();
 
         if ($relation instanceof BelongsTo) {
-            $foreignKeyMethod = version_compare(app()->version(), '5.8.0', '<') ? 'getForeignKey' : 'getForeignKeyName';
-
             return [
                 $relatedTable,
-                $relation->{$foreignKeyMethod}(),
+                $relation->getForeignKeyName(),
                 '=',
                 $relatedTable.'.'.$relation->getRelated()->getKeyName(),
             ];
@@ -872,9 +870,8 @@ class EloquentRepository extends Repository implements TreeRepository
                     $parent->save();
 
                     // When in creating, associate two models
-                    $foreignKeyMethod = version_compare(app()->version(), '5.8.0', '<') ? 'getForeignKey' : 'getForeignKeyName';
-                    if (! $model->{$relation->{$foreignKeyMethod}()}) {
-                        $model->{$relation->{$foreignKeyMethod}()} = $parent->getKey();
+                    if (! $model->{$relation->getForeignKeyName()}) {
+                        $model->{$relation->getForeignKeyName()} = $parent->getKey();
 
                         $model->save();
                     }

--- a/src/Scaffold/ModelCreator.php
+++ b/src/Scaffold/ModelCreator.php
@@ -171,12 +171,8 @@ class ModelCreator
      */
     protected function replaceDatetimeFormatter(&$stub)
     {
-        $import = $use = '';
-
-        if (version_compare(app()->version(), '7.0.0') >= 0) {
-            $import = 'use Dcat\\Admin\\Traits\\HasDateTimeFormatter;';
-            $use = 'use HasDateTimeFormatter;';
-        }
+        $import = 'use Dcat\\Admin\\Traits\\HasDateTimeFormatter;';
+        $use = 'use HasDateTimeFormatter;';
 
         $stub = str_replace(['DummyImportDateTimeFormatterTrait', 'DummyUseDateTimeFormatterTrait'], [$import, $use], $stub);
 

--- a/src/Support/Translator.php
+++ b/src/Support/Translator.php
@@ -110,7 +110,7 @@ class Translator
     protected function getTranslateMethod()
     {
         if (static::$method === null) {
-            static::$method = version_compare(app()->version(), '6.0', '>=') ? 'get' : 'trans';
+            static::$method = 'get';
         }
 
         return static::$method;


### PR DESCRIPTION
## Summary

- `spatie/eloquent-sortable` 约束从 `4.*` 扩展为 `^4.0|^5.0`，5.x 支持 Laravel 13
- 移除 `doctrine/dbal` 依赖（源码零引用，Laravel 11+ 已不依赖）
- `phpunit/phpunit` 约束补充 `^13.0`
- 清理 5 处遗留 `version_compare` 死代码（比较 Laravel 5.8/6.0/7.0/8.0，最低支持版本已是 Laravel 10）
- 更新描述：支持 Laravel 10-13，PHP 8.5

## 兼容性

| 场景 | 兼容 |
|---|---|
| Laravel 10/11/12 + PHP 8.1 | ✅ spatie 4.x |
| Laravel 13 + PHP 8.3+ | ✅ spatie 5.x |

## Test plan

- [ ] `composer install` 在 Laravel 10 项目中成功
- [x] `composer install` 在 Laravel 13 项目中成功
- [x] 菜单排序功能正常
- [x] 权限树排序功能正常
- [x] Grid 行上移/下移功能正常