### PR TITLE
fix: 修复表单提交参数重复问题 (#22)

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,5 @@
+node_modules/
+resources/dist/
+resources/assets/dcat/plugins/
+resources/assets/adminlte/
+vendor/

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,27 @@
+{
+    "esversion": 11,
+    "browser": true,
+    "module": true,
+    "jquery": true,
+    "undef": true,
+    "unused": true,
+    "eqeqeq": true,
+    "curly": true,
+    "strict": false,
+    "globals": {
+        "Dcat": true,
+        "NProgress": true,
+        "Swal": true,
+        "toastr": true,
+        "axios": true,
+        "moment": true,
+        "Pjax": true,
+        "layui": true,
+        "tinymce": true,
+        "SimpleMDE": true,
+        "marked": true,
+        "UE": true,
+        "wangEditor": true,
+        "HtmlEditor": true
+    }
+}

--- a/resources/views/form/multipleselect.blade.php
+++ b/resources/views/form/multipleselect.blade.php
@@ -13,7 +13,7 @@
                 <option value="{{ $select }}" {{  in_array($select, (array) $value) ?'selected':'' }}>{{$option}}</option>
             @endforeach
         </select>
-        <input type="hidden" name="{{$name}}[]" />
+        <input type="hidden" name="{{$name}}[]" {!! $value ? 'disabled' : '' !!}/>
 
         @include('admin::form.help-block')
 
@@ -21,3 +21,9 @@
 </div>
 
 @include('admin::form.select-script')
+
+<script>
+$('.{{$selector}}').on('change.select2', function () {
+    $(this).next('input[type="hidden"]').prop('disabled', $(this).val()?.length > 0);
+});
+</script>

--- a/resources/views/form/multipleselect.blade.php
+++ b/resources/views/form/multipleselect.blade.php
@@ -23,7 +23,7 @@
 @include('admin::form.select-script')
 
 <script>
-$('.{{$selector}}').on('change.select2', function () {
-    $(this).next('input[type="hidden"]').prop('disabled', $(this).val()?.length > 0);
+$('.{{$selector}}').off('change.select2').on('change.select2', function () {
+    $(this).closest('.field').find('input[type="hidden"][name="{{$name}}[]"]').prop('disabled', $(this).val()?.length > 0);
 });
 </script>

--- a/src/Form/Builder.php
+++ b/src/Form/Builder.php
@@ -722,9 +722,7 @@ class Builder implements FieldsCollection
                 );
             }
 
-            $content = $this->layout->build(
-                $this->renderHiddenFields()
-            );
+            $content = $this->layout->build();
         }
 
         return "{$open}{$content}{$this->close()}";


### PR DESCRIPTION
## Summary

- 修复 `Builder::render()` 中 `renderHiddenFields()` 被调用两次，导致 `_method`、`_previous_` 等隐藏字段在 DOM 中重复
- 修复 MultipleSelect 字段的隐藏 input 在有选中值时仍提交空值的问题

## 问题根因

### 隐藏字段重复

`Builder::render()` 在默认布局路径（无 columns、无 blocks）和 hasBlocks 路径中，`renderHiddenFields()` 被调用了两次：

1. `container.blade.php:18` — `{!! $form->renderHiddenFields() !!}`
2. `Builder::render():726` — `$this->layout->build($this->renderHiddenFields())`

jquery-form 的 `ajaxSubmit` 通过 `form.elements` 序列化所有表单元素，两个重复的 `<input>` 都被收集，导致 payload 中出现 `_method=PUT&_method=PUT`。

### MultipleSelect 空值重复

`multipleselect.blade.php` 中 `<input type="hidden" name="{{$name}}[]" />` 与 `<select>` 同名，选中值时两者同时提交，导致数组混入空值。

## 修复方式

- 移除 `Builder::render()` 中 `build()` 对 `renderHiddenFields()` 的冗余调用
- MultipleSelect 的隐藏 input 根据选中状态动态 `disabled`，Select2 变更时通过 `change.select2` 事件切换

## Test plan

- [x] 编辑页面提交，确认 `_method` 和 `_previous_` 不再重复
- [x] MultipleSelect 选中值时确认 payload 中无空值
- [x] MultipleSelect 清空选择时确认服务端收到空数组
- [x] hasColumns 布局的表单 hidden fields 仍正常渲染
- [x] create 模式表单无回归

Closes #22