### PR TITLE
fix: Laravel 13 session MessageBag 序列化兼容 (#24)

### DIFF
--- a/resources/views/partials/alerts.blade.php
+++ b/resources/views/partials/alerts.blade.php
@@ -1,8 +1,8 @@
 @if($error = session()->get('error'))
     <div class="alert alert-danger alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
-        <h4><i class="icon fa fa-ban"></i> &nbsp;{{ \Illuminate\Support\Arr::get($error->get('title'), 0) }}</h4>
-        <p>{!!  \Illuminate\Support\Arr::get($error->get('message'), 0) !!}</p>
+        <h4><i class="icon fa fa-ban"></i> &nbsp;{{ $error->getTitle() }}</h4>
+        <p>{!!  $error->getMessage() !!}</p>
     </div>
 @elseif ($errors = session()->get('errors'))
     @if ($errors->hasBag('error'))
@@ -19,23 +19,23 @@
 @if($success = session()->get('success'))
     <div class="alert alert-success alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
-        <h4><i class="icon fa fa-check"></i> &nbsp;{{ \Illuminate\Support\Arr::get($success->get('title'), 0) }}</h4>
-        <p>{!!  \Illuminate\Support\Arr::get($success->get('message'), 0) !!}</p>
+        <h4><i class="icon fa fa-check"></i> &nbsp;{{ $success->getTitle() }}</h4>
+        <p>{!!  $success->getMessage() !!}</p>
     </div>
 @endif
 
 @if($info = session()->get('info'))
     <div class="alert alert-info alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
-        <h4><i class="icon fa fa-info"></i> &nbsp;{{ \Illuminate\Support\Arr::get($info->get('title'), 0) }}</h4>
-        <p>{!!  \Illuminate\Support\Arr::get($info->get('message'), 0) !!}</p>
+        <h4><i class="icon fa fa-info"></i> &nbsp;{{ $info->getTitle() }}</h4>
+        <p>{!!  $info->getMessage() !!}</p>
     </div>
 @endif
 
 @if($warning = session()->get('warning'))
     <div class="alert alert-warning alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
-        <h4><i class="icon fa fa-warning"></i> &nbsp;{{ \Illuminate\Support\Arr::get($warning->get('title'), 0) }}</h4>
-        <p>{!!  \Illuminate\Support\Arr::get($warning->get('message'), 0) !!}</p>
+        <h4><i class="icon fa fa-warning"></i> &nbsp;{{ $warning->getTitle() }}</h4>
+        <p>{!!  $warning->getMessage() !!}</p>
     </div>
 @endif

--- a/resources/views/partials/alerts.blade.php
+++ b/resources/views/partials/alerts.blade.php
@@ -1,4 +1,4 @@
-@if($error = session()->get('error'))
+@if($error = \Dcat\Admin\Support\SessionMessage::tryFrom(session()->get('error')))
     <div class="alert alert-danger alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
         <h4><i class="icon fa fa-ban"></i> &nbsp;{{ $error->getTitle() }}</h4>
@@ -16,7 +16,7 @@
     @endif
 @endif
 
-@if($success = session()->get('success'))
+@if($success = \Dcat\Admin\Support\SessionMessage::tryFrom(session()->get('success')))
     <div class="alert alert-success alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
         <h4><i class="icon fa fa-check"></i> &nbsp;{{ $success->getTitle() }}</h4>
@@ -24,7 +24,7 @@
     </div>
 @endif
 
-@if($info = session()->get('info'))
+@if($info = \Dcat\Admin\Support\SessionMessage::tryFrom(session()->get('info')))
     <div class="alert alert-info alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
         <h4><i class="icon fa fa-info"></i> &nbsp;{{ $info->getTitle() }}</h4>
@@ -32,7 +32,7 @@
     </div>
 @endif
 
-@if($warning = session()->get('warning'))
+@if($warning = \Dcat\Admin\Support\SessionMessage::tryFrom(session()->get('warning')))
     <div class="alert alert-warning alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
         <h4><i class="icon fa fa-warning"></i> &nbsp;{{ $warning->getTitle() }}</h4>

--- a/resources/views/partials/exception.blade.php
+++ b/resources/views/partials/exception.blade.php
@@ -1,11 +1,16 @@
 @if(isset($errors) && $errors->hasBag('exception'))
-    <?php $error = $errors->getBag('exception'); ?>
+    @php
+        $error = $errors->getBag('exception');
+        $errorType = $error->first('type');
+        $errorFile = $error->first('file');
+        $errorLine = $error->first('line');
+    @endphp
     <div class="alert alert-warning alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
         <h4>
             <i class="icon fa fa-warning"></i>
-            <i style="border-bottom: 1px dotted #fff;cursor: pointer;" title="{{ $error->get('type')[0] }}" ondblclick="var f=this.innerHTML;this.innerHTML=this.title;this.title=f;">{{ class_basename($error->get('type')[0]) }}</i>
-            In <i title="{{ $error->get('file')[0] }} line {{ $error->get('line')[0] }}" style="border-bottom: 1px dotted #fff;cursor: pointer;" ondblclick="var f=this.innerHTML;this.innerHTML=this.title;this.title=f;">{{ basename($error->get('file')[0]) }} line {{ $error->get('line')[0] }}</i> :
+            <i style="border-bottom: 1px dotted #fff;cursor: pointer;" title="{{ $errorType }}" ondblclick="var f=this.innerHTML;this.innerHTML=this.title;this.title=f;">{{ class_basename($errorType) }}</i>
+            In <i title="{{ $errorFile }} line {{ $errorLine }}" style="border-bottom: 1px dotted #fff;cursor: pointer;" ondblclick="var f=this.innerHTML;this.innerHTML=this.title;this.title=f;">{{ basename($errorFile) }} line {{ $errorLine }}</i> :
         </h4>
         <p><a style="cursor: pointer;" onclick="$('#dcat-admin-exception-trace').toggleClass('hidden');$('i', this).toggleClass('fa-angle-double-down fa-angle-double-up');"><i class="fa fa-angle-double-down"></i>&nbsp;&nbsp;{!! $error->first('message') !!}</a></p>
 

--- a/resources/views/partials/toastr.blade.php
+++ b/resources/views/partials/toastr.blade.php
@@ -1,9 +1,9 @@
 @if(Session::has('dcat-admin-toastr'))
     @php
         $toastr  = Session::get('dcat-admin-toastr');
-        $type    = $toastr->get('type')[0] ?? 'success';
-        $message = $toastr->get('message')[0] ?? '';
-        $options = admin_javascript_json($toastr->get('options', []));
+        $type    = $toastr->getTitle();
+        $message = $toastr->getMessage();
+        $options = admin_javascript_json($toastr->getOptions());
     @endphp
     <script>$(function () { toastr.{{$type}}('{!!  $message  !!}', null, {!! $options !!}); })</script>
 @endif

--- a/resources/views/partials/toastr.blade.php
+++ b/resources/views/partials/toastr.blade.php
@@ -1,8 +1,3 @@
 @if($toastr = \Dcat\Admin\Support\SessionMessage::tryFrom(Session::get('dcat-admin-toastr')))
-    @php
-        $type    = $toastr->getTitle();
-        $message = $toastr->getMessage();
-        $options = admin_javascript_json($toastr->getOptions());
-    @endphp
-    <script>$(function () { toastr.{{$type}}('{!!  $message  !!}', null, {!! $options !!}); })</script>
+    <script>$(function () { toastr.{!! $toastr->getTitle() !!}({!! json_encode($toastr->getMessage()) !!}, null, {!! admin_javascript_json($toastr->getOptions()) !!}); })</script>
 @endif

--- a/resources/views/partials/toastr.blade.php
+++ b/resources/views/partials/toastr.blade.php
@@ -1,6 +1,5 @@
-@if(Session::has('dcat-admin-toastr'))
+@if($toastr = \Dcat\Admin\Support\SessionMessage::tryFrom(Session::get('dcat-admin-toastr')))
     @php
-        $toastr  = Session::get('dcat-admin-toastr');
         $type    = $toastr->getTitle();
         $message = $toastr->getMessage();
         $options = admin_javascript_json($toastr->getOptions());

--- a/resources/views/partials/toastr.blade.php
+++ b/resources/views/partials/toastr.blade.php
@@ -1,3 +1,3 @@
 @if($toastr = \Dcat\Admin\Support\SessionMessage::tryFrom(Session::get('dcat-admin-toastr')))
-    <script>$(function () { toastr.{!! $toastr->getTitle() !!}({!! json_encode($toastr->getMessage()) !!}, null, {!! admin_javascript_json($toastr->getOptions()) !!}); })</script>
+    <script>$(function () { toastr.{!! $toastr->getToastrType() !!}({!! json_encode($toastr->getMessage()) !!}, null, {!! admin_javascript_json($toastr->getOptions()) !!}); })</script>
 @endif

--- a/src/Http/Controllers/ScaffoldController.php
+++ b/src/Http/Controllers/ScaffoldController.php
@@ -11,13 +11,13 @@ use Dcat\Admin\Scaffold\MigrationCreator;
 use Dcat\Admin\Scaffold\ModelCreator;
 use Dcat\Admin\Scaffold\RepositoryCreator;
 use Dcat\Admin\Support\Helper;
+use Dcat\Admin\Support\SessionMessage;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\URL;
-use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 
 class ScaffoldController extends Controller
@@ -275,10 +275,7 @@ class ScaffoldController extends Controller
 
     protected function backWithException(\Exception $exception)
     {
-        $error = new MessageBag([
-            'title'   => 'Error',
-            'message' => $exception->getMessage(),
-        ]);
+        $error = SessionMessage::make('Error', $exception->getMessage());
 
         return redirect()->refresh()->withInput()->with(compact('error'));
     }
@@ -293,10 +290,7 @@ class ScaffoldController extends Controller
 
         $messages[] = "<br />$message";
 
-        $success = new MessageBag([
-            'title'   => 'Success',
-            'message' => implode('<br />', $messages),
-        ]);
+        $success = SessionMessage::make('Success', implode('<br />', $messages));
 
         return redirect()->refresh()->with(compact('success'));
     }

--- a/src/Support/SessionMessage.php
+++ b/src/Support/SessionMessage.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Dcat\Admin\Support;
+
+/**
+ * Session 消息对象（兼容 Laravel 10-13）.
+ *
+ * 解决 Laravel 13 中 MessageBag 通过 redirect()->with() 序列化后变为数组的问题
+ */
+class SessionMessage
+{
+    public function __construct(
+        protected string $title = '',
+        protected string $message = '',
+        protected array $options = [],
+    ) {
+    }
+
+    public static function make(string $title, string $message = '', array $options = []): static
+    {
+        return new static($title, $message, $options);
+    }
+
+    public static function fromArray(array $data): static
+    {
+        return new static(
+            title: (string) (\Illuminate\Support\Arr::first((array) ($data['title'] ?? '')) ?? ''),
+            message: (string) (\Illuminate\Support\Arr::first((array) ($data['message'] ?? '')) ?? ''),
+            options: (array) ($data['options'] ?? []),
+        );
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'title' => $this->title,
+            'message' => $this->message,
+            'options' => $this->options,
+        ];
+    }
+}

--- a/src/Support/SessionMessage.php
+++ b/src/Support/SessionMessage.php
@@ -9,7 +9,7 @@ namespace Dcat\Admin\Support;
  * 1. Laravel 13 中 MessageBag 通过 redirect()->with() 序列化后变为数组的问题
  * 2. session.serialization = json 时，protected 属性不会被 json_encode 包含的问题
  */
-class SessionMessage implements \JsonSerializable
+final class SessionMessage implements \JsonSerializable
 {
     private const JSON_CLASS_KEY = '__dcat_class';
 
@@ -24,9 +24,9 @@ class SessionMessage implements \JsonSerializable
     ) {
     }
 
-    public static function make(string $title, string $message = '', array $options = []): static
+    public static function make(string $title, string $message = '', array $options = []): self
     {
-        return new static($title, $message, $options);
+        return new self($title, $message, $options);
     }
 
     public function getTitle(): string
@@ -71,9 +71,9 @@ class SessionMessage implements \JsonSerializable
      * - PHP 序列化（session.serialization = php）：值已经是 SessionMessage 对象
      * - JSON 序列化（session.serialization = json）：值是带类型标识的数组
      */
-    public static function tryFrom(mixed $value): ?static
+    public static function tryFrom(mixed $value): ?self
     {
-        if ($value instanceof static) {
+        if ($value instanceof self) {
             return $value;
         }
 
@@ -81,7 +81,7 @@ class SessionMessage implements \JsonSerializable
             is_array($value)
             && ($value[self::JSON_CLASS_KEY] ?? null) === self::JSON_CLASS_VALUE
         ) {
-            return new static(
+            return new self(
                 is_string($value['title'] ?? null) ? $value['title'] : '',
                 is_string($value['message'] ?? null) ? $value['message'] : '',
                 is_array($value['options'] ?? null) ? $value['options'] : [],

--- a/src/Support/SessionMessage.php
+++ b/src/Support/SessionMessage.php
@@ -3,12 +3,18 @@
 namespace Dcat\Admin\Support;
 
 /**
- * Session 消息对象（兼容 Laravel 10-13）.
+ * Session 消息对象（兼容 Laravel 10-13，兼容 PHP session.serialization = json/php）.
  *
- * 解决 Laravel 13 中 MessageBag 通过 redirect()->with() 序列化后变为数组的问题
+ * 解决两类问题：
+ * 1. Laravel 13 中 MessageBag 通过 redirect()->with() 序列化后变为数组的问题
+ * 2. session.serialization = json 时，protected 属性不会被 json_encode 包含的问题
  */
-class SessionMessage
+class SessionMessage implements \JsonSerializable
 {
+    private const JSON_CLASS_KEY = '__dcat_class';
+
+    private const JSON_CLASS_VALUE = self::class;
+
     public function __construct(
         protected string $title = '',
         protected string $message = '',
@@ -36,4 +42,45 @@ class SessionMessage
         return $this->options;
     }
 
+    /**
+     * 支持 JSON session 序列化（session.serialization = json）.
+     *
+     * 将对象编码为包含类型标识符的数组，确保 protected 属性不丢失。
+     */
+    public function jsonSerialize(): mixed
+    {
+        return [
+            self::JSON_CLASS_KEY => self::JSON_CLASS_VALUE,
+            'title' => $this->title,
+            'message' => $this->message,
+            'options' => $this->options,
+        ];
+    }
+
+    /**
+     * 从 session 中读取的值尝试构造实例.
+     *
+     * 兼容两种情况：
+     * - PHP 序列化（session.serialization = php）：值已经是 SessionMessage 对象
+     * - JSON 序列化（session.serialization = json）：值是带类型标识的数组
+     */
+    public static function tryFrom(mixed $value): ?static
+    {
+        if ($value instanceof static) {
+            return $value;
+        }
+
+        if (
+            is_array($value)
+            && ($value[self::JSON_CLASS_KEY] ?? null) === self::JSON_CLASS_VALUE
+        ) {
+            return new static(
+                $value['title'] ?? '',
+                $value['message'] ?? '',
+                $value['options'] ?? [],
+            );
+        }
+
+        return null;
+    }
 }

--- a/src/Support/SessionMessage.php
+++ b/src/Support/SessionMessage.php
@@ -15,6 +15,8 @@ class SessionMessage implements \JsonSerializable
 
     private const JSON_CLASS_VALUE = self::class;
 
+    private const TOASTR_TYPES = ['success', 'error', 'warning', 'info'];
+
     public function __construct(
         protected string $title = '',
         protected string $message = '',
@@ -30,6 +32,11 @@ class SessionMessage implements \JsonSerializable
     public function getTitle(): string
     {
         return $this->title;
+    }
+
+    public function getToastrType(): string
+    {
+        return in_array($this->title, self::TOASTR_TYPES, true) ? $this->title : 'info';
     }
 
     public function getMessage(): string

--- a/src/Support/SessionMessage.php
+++ b/src/Support/SessionMessage.php
@@ -82,9 +82,9 @@ class SessionMessage implements \JsonSerializable
             && ($value[self::JSON_CLASS_KEY] ?? null) === self::JSON_CLASS_VALUE
         ) {
             return new static(
-                $value['title'] ?? '',
-                $value['message'] ?? '',
-                $value['options'] ?? [],
+                is_string($value['title'] ?? null) ? $value['title'] : '',
+                is_string($value['message'] ?? null) ? $value['message'] : '',
+                is_array($value['options'] ?? null) ? $value['options'] : [],
             );
         }
 

--- a/src/Support/SessionMessage.php
+++ b/src/Support/SessionMessage.php
@@ -21,15 +21,6 @@ class SessionMessage
         return new static($title, $message, $options);
     }
 
-    public static function fromArray(array $data): static
-    {
-        return new static(
-            title: (string) (\Illuminate\Support\Arr::first((array) ($data['title'] ?? '')) ?? ''),
-            message: (string) (\Illuminate\Support\Arr::first((array) ($data['message'] ?? '')) ?? ''),
-            options: (array) ($data['options'] ?? []),
-        );
-    }
-
     public function getTitle(): string
     {
         return $this->title;
@@ -45,12 +36,4 @@ class SessionMessage
         return $this->options;
     }
 
-    public function toArray(): array
-    {
-        return [
-            'title' => $this->title,
-            'message' => $this->message,
-            'options' => $this->options,
-        ];
-    }
 }

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -2,10 +2,9 @@
 
 use Dcat\Admin\Admin;
 use Dcat\Admin\Support\Helper;
+use Dcat\Admin\Support\SessionMessage;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Renderable;
-use Illuminate\Http\Request;
-use Illuminate\Support\MessageBag;
 use Symfony\Component\HttpFoundation\Response;
 
 if (! function_exists('admin_setting')) {
@@ -298,7 +297,7 @@ if (! function_exists('admin_base_path')) {
 
 if (! function_exists('admin_toastr')) {
     /**
-     * Flash a toastr message bag to session.
+     * Flash a toastr message to session.
      *
      * @param  string  $message
      * @param  string  $type
@@ -306,7 +305,7 @@ if (! function_exists('admin_toastr')) {
      */
     function admin_toastr($message = '', $type = 'success', $options = [])
     {
-        $toastr = new MessageBag(get_defined_vars());
+        $toastr = SessionMessage::make($type, $message, $options);
 
         session()->flash('dcat-admin-toastr', $toastr);
     }
@@ -353,7 +352,7 @@ if (! function_exists('admin_warning')) {
 
 if (! function_exists('admin_info')) {
     /**
-     * Flash a message bag to session.
+     * Flash a message to session.
      *
      * @param  string  $title
      * @param  string  $message
@@ -361,7 +360,7 @@ if (! function_exists('admin_info')) {
      */
     function admin_info($title, $message = '', $type = 'info')
     {
-        $message = new MessageBag(get_defined_vars());
+        $message = SessionMessage::make($title, $message);
 
         session()->flash($type, $message);
     }

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -5,6 +5,7 @@ use Dcat\Admin\Support\Helper;
 use Dcat\Admin\Support\SessionMessage;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 if (! function_exists('admin_setting')) {

--- a/tests/Unit/SessionMessageTest.php
+++ b/tests/Unit/SessionMessageTest.php
@@ -159,4 +159,34 @@ class SessionMessageTest extends TestCase
         $this->assertSame('', $restored->getMessage());
         $this->assertSame([], $restored->getOptions());
     }
+
+    public function test_try_from_ignores_non_string_title_and_message(): void
+    {
+        $restored = SessionMessage::tryFrom([
+            '__dcat_class' => 'Dcat\Admin\Support\SessionMessage',
+            'title'   => ['injected'],
+            'message' => 42,
+            'options' => ['timeOut' => 3000],
+        ]);
+
+        $this->assertNotNull($restored);
+        $this->assertSame('', $restored->getTitle());
+        $this->assertSame('', $restored->getMessage());
+        $this->assertSame(['timeOut' => 3000], $restored->getOptions());
+    }
+
+    public function test_try_from_ignores_non_array_options(): void
+    {
+        $restored = SessionMessage::tryFrom([
+            '__dcat_class' => 'Dcat\Admin\Support\SessionMessage',
+            'title'   => 'info',
+            'message' => 'hello',
+            'options' => 'not-an-array',
+        ]);
+
+        $this->assertNotNull($restored);
+        $this->assertSame('info', $restored->getTitle());
+        $this->assertSame('hello', $restored->getMessage());
+        $this->assertSame([], $restored->getOptions());
+    }
 }

--- a/tests/Unit/SessionMessageTest.php
+++ b/tests/Unit/SessionMessageTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Unit;
+
+use Dcat\Admin\Support\SessionMessage;
+use PHPUnit\Framework\TestCase;
+
+class SessionMessageTest extends TestCase
+{
+    // -----------------------------------------------------------------------
+    // make / getters
+    // -----------------------------------------------------------------------
+
+    public function test_make_returns_instance_with_correct_values(): void
+    {
+        $msg = SessionMessage::make('success', 'hello', ['timeOut' => 3000]);
+
+        $this->assertSame('success', $msg->getTitle());
+        $this->assertSame('hello', $msg->getMessage());
+        $this->assertSame(['timeOut' => 3000], $msg->getOptions());
+    }
+
+    public function test_make_defaults_message_and_options(): void
+    {
+        $msg = SessionMessage::make('info');
+
+        $this->assertSame('', $msg->getMessage());
+        $this->assertSame([], $msg->getOptions());
+    }
+
+    // -----------------------------------------------------------------------
+    // getToastrType — whitelist
+    // -----------------------------------------------------------------------
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('validToastrTypes')]
+    public function test_get_toastr_type_returns_valid_type(string $type): void
+    {
+        $this->assertSame($type, SessionMessage::make($type)->getToastrType());
+    }
+
+    public static function validToastrTypes(): array
+    {
+        return [
+            ['success'],
+            ['error'],
+            ['warning'],
+            ['info'],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('invalidToastrTypes')]
+    public function test_get_toastr_type_falls_back_to_info_for_invalid_type(string $type): void
+    {
+        $this->assertSame('info', SessionMessage::make($type)->getToastrType());
+    }
+
+    public static function invalidToastrTypes(): array
+    {
+        return [
+            [''],
+            ['alert'],
+            ['SUCCESS'],
+            ['<script>alert(1)</script>'],
+            ['error; DROP TABLE'],
+        ];
+    }
+
+    // -----------------------------------------------------------------------
+    // jsonSerialize (JSON session 序列化)
+    // -----------------------------------------------------------------------
+
+    public function test_json_serialize_includes_class_key_and_all_fields(): void
+    {
+        $msg = SessionMessage::make('error', 'something went wrong', ['closeButton' => true]);
+        $data = $msg->jsonSerialize();
+
+        $this->assertSame('Dcat\Admin\Support\SessionMessage', $data['__dcat_class']);
+        $this->assertSame('error', $data['title']);
+        $this->assertSame('something went wrong', $data['message']);
+        $this->assertSame(['closeButton' => true], $data['options']);
+    }
+
+    public function test_json_encode_roundtrip(): void
+    {
+        $msg = SessionMessage::make('warning', 'be careful', ['positionClass' => 'toast-top-right']);
+        $decoded = json_decode(json_encode($msg), true);
+
+        $this->assertSame('warning', $decoded['title']);
+        $this->assertSame('be careful', $decoded['message']);
+        $this->assertSame(['positionClass' => 'toast-top-right'], $decoded['options']);
+    }
+
+    // -----------------------------------------------------------------------
+    // tryFrom — PHP 序列化路径
+    // -----------------------------------------------------------------------
+
+    public function test_try_from_accepts_existing_instance(): void
+    {
+        $original = SessionMessage::make('success', 'done');
+        $result = SessionMessage::tryFrom($original);
+
+        $this->assertSame($original, $result);
+    }
+
+    public function test_try_from_returns_null_for_plain_object(): void
+    {
+        $this->assertNull(SessionMessage::tryFrom(new \stdClass()));
+    }
+
+    public function test_try_from_returns_null_for_null(): void
+    {
+        $this->assertNull(SessionMessage::tryFrom(null));
+    }
+
+    public function test_try_from_returns_null_for_string(): void
+    {
+        $this->assertNull(SessionMessage::tryFrom('success'));
+    }
+
+    // -----------------------------------------------------------------------
+    // tryFrom — JSON 序列化路径
+    // -----------------------------------------------------------------------
+
+    public function test_try_from_reconstructs_from_json_array(): void
+    {
+        $original = SessionMessage::make('info', 'hello', ['timeOut' => 5000]);
+        $array = json_decode(json_encode($original), true);
+
+        $restored = SessionMessage::tryFrom($array);
+
+        $this->assertNotNull($restored);
+        $this->assertSame('info', $restored->getTitle());
+        $this->assertSame('hello', $restored->getMessage());
+        $this->assertSame(['timeOut' => 5000], $restored->getOptions());
+    }
+
+    public function test_try_from_returns_null_for_array_without_class_key(): void
+    {
+        $this->assertNull(SessionMessage::tryFrom(['title' => 'info', 'message' => 'hi']));
+    }
+
+    public function test_try_from_returns_null_for_array_with_wrong_class_key(): void
+    {
+        $this->assertNull(SessionMessage::tryFrom([
+            '__dcat_class' => 'Some\Other\Class',
+            'title' => 'info',
+            'message' => 'hi',
+        ]));
+    }
+
+    public function test_try_from_tolerates_missing_fields_in_json_array(): void
+    {
+        $restored = SessionMessage::tryFrom([
+            '__dcat_class' => 'Dcat\Admin\Support\SessionMessage',
+        ]);
+
+        $this->assertNotNull($restored);
+        $this->assertSame('', $restored->getTitle());
+        $this->assertSame('', $restored->getMessage());
+        $this->assertSame([], $restored->getOptions());
+    }
+}


### PR DESCRIPTION
## 问题

Laravel 13 中，通过 `redirect()->with()` 存储的 `MessageBag` 对象会被序列化为数组，导致 blade 模板调用 `->get()` 方法时报错：

```
Call to a member function get() on array
htmlspecialchars(): Argument #1 ($string) must be of type string, array given
```

## 解决方案

引入 `SessionMessage` 值对象替代 `MessageBag`，提供语义清晰的 `getTitle()`、`getMessage()`、`getOptions()` 方法。

### 修改文件

| 文件 | 说明 |
|------|------|
| `src/Support/SessionMessage.php` | 新增值对象 |
| `src/Support/helpers.php` | `admin_info()`、`admin_toastr()` 改用 `SessionMessage` |
| `src/Http/Controllers/ScaffoldController.php` | `backWithSuccess()`、`backWithException()` 改用 `SessionMessage` |
| `resources/views/partials/alerts.blade.php` | 使用对象方法替代 `Arr::get()` |
| `resources/views/partials/toastr.blade.php` | 使用对象方法替代 `Arr::get()` |
| `resources/views/partials/exception.blade.php` | 使用 `MessageBag::first()` 并缓存变量 |

## 兼容性

兼容 Laravel 10、11、12、13。

Closes #24