### PR TITLE
fix: stop encoding underscores in HTML attribute values

### DIFF
--- a/src/Support/Helper.php
+++ b/src/Support/Helper.php
@@ -151,7 +151,9 @@ class Helper
             $element = '';
 
             if ($value !== null) {
-                $element = $key.'="'.htmlentities($value, ENT_QUOTES | ENT_HTML5, 'UTF-8').'" ';
+                // FIX: ENT_HTML5 named-entity table encodes "_" -> "&lowbar;" etc.,
+                // breaking attribute values like name="foo_bar". Use ENT_QUOTES only.
+                $element = $key.'="'.htmlentities($value, ENT_QUOTES, 'UTF-8').'" ';
             }
 
             $html .= $element;


### PR DESCRIPTION
## Problem

`Helper::buildHtmlAttributes()` serializes widget attributes via:

```php
htmlentities($value, ENT_QUOTES | ENT_HTML5, 'UTF-8')
```

The HTML5 named-entity table encodes `_` as `&lowbar;`, ` ` as `&nbsp;`, and many other ordinary characters that should not appear as entities inside an attribute value. When the resulting attribute is later combined with another layer of escaping (e.g. `&` → `&amp;`), the source HTML for a Radio widget ends up like:

```html
<input value="..." name="account&amp;lowbar;category" type="radio">
```

…which the browser parses into a DOM attribute whose literal value is `account&lowbar;category` (with literal `&` and the chars `lowbar;`), **not** `account_category`. That breaks:

- `document.querySelector('[name="account_category"]')` — finds 0 elements
- jQuery `$('[name="account_category"]')` — finds 0 elements
- Form submission — the POST body contains `account&lowbar;category=...` instead of `account_category=...`, so the controller never sees the value under its expected key

## Repro

```php
// in any Form callback
$form->radio('account_category', '科目分類')
    ->options(['a' => 'A', 'b' => 'B']);
```

Inspect the rendered HTML — every radio `<input>` has `name="account&amp;lowbar;category"`.

## Affected widgets

Anything that goes through `Helper::buildHtmlAttributes()` via `formatHtmlAttributes()`:
Radio, Checkbox, Switch, and any custom `Widget` subclass. Standard form fields rendered through Blade `{{ }}` are not affected.

## Fix

Switch the entity flag set to `ENT_QUOTES` only — the same character set `htmlspecialchars()` uses, which is the correct rule for serializing HTML attribute values (`& < > " '` only):

```diff
- $element = $key.'="'.htmlentities($value, ENT_QUOTES | ENT_HTML5, 'UTF-8').'" ';
+ // FIX: ENT_HTML5 named-entity table encodes "_" -> "&lowbar;" etc.,
+ // breaking attribute values like name="foo_bar". Use ENT_QUOTES only.
+ $element = $key.'="'.htmlentities($value, ENT_QUOTES, 'UTF-8').'" ';
```

Before:
```html
name="account&amp;lowbar;category" class="field&amp;lowbar;account&amp;lowbar;category"
```

After:
```html
name="account_category" class="field_account_category"
```

## Notes

- No behaviour change for attribute values that contain only ASCII letters/digits/no special chars.
- For values that contain `& < > " '`, behaviour is identical to `htmlspecialchars($v, ENT_QUOTES)`.
- For values that contain non-ASCII (e.g. CJK), they are still emitted as-is in UTF-8 (no entity conversion), which is what attribute serialization should do and what every browser parses correctly.