### PR TITLE
feat: 支持通过配置独立控制 JS/CSS 资源缓存版本号

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 > 更多功能正在持续开发... 欢迎交流评论
 
+- 支持通过 `admin.assets_version` 配置项（或 `ADMIN_ASSETS_VERSION` 环境变量）自定义 JS/CSS 缓存破坏版本号，不再强制跟随框架版本
 - [2025/08/05 增强对枚举字段的渲染支持](https://github.com/PrintNow/dcat-admin/pull/5)
 - [@deflinhec : 修正 Grid 以 LazyRenderable 呈現時Group Filter 沒有正確篩選](https://github.com/PrintNow/dcat-admin/commit/4390a8f494c20910828e7c93513d13032f0d01dd)
 - [新增 highlightjs 类以支持代码块高亮显示](https://github.com/PrintNow/dcat-admin/commit/52050882eea475b9d3863ace98048404f7d320b7)

--- a/config/admin.php
+++ b/config/admin.php
@@ -106,6 +106,18 @@ return [
    */
     'assets_server' => env('ADMIN_ASSETS_SERVER'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Assets version
+    |--------------------------------------------------------------------------
+    |
+    | The version string appended to JS/CSS URLs as a cache-busting query
+    | parameter (e.g. `?v1.0.0`). Defaults to the framework version. Set to
+    | null/empty to disable the version query entirely.
+    |
+    */
+    'assets_version' => env('ADMIN_ASSETS_VERSION'),
+
     /**
      * @deprecated 不再建议使用此配置。如果你使用了反向代理，配置好 `app/Http/Middleware/TrustProxies.php` 中的 $proxies 属性，
      *             页面就会自动使用 https 协议。未来将完全移除此配置。

--- a/src/Console/stubs/config.stub
+++ b/src/Console/stubs/config.stub
@@ -106,6 +106,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Assets version
+    |--------------------------------------------------------------------------
+    |
+    | The version string appended to JS/CSS URLs as a cache-busting query
+    | parameter (e.g. `?v1.0.0`). Defaults to the framework version. Set to
+    | null/empty to disable the version query entirely.
+    |
+    */
+    'assets_version' => env('ADMIN_ASSETS_VERSION'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Access via `https`
     |--------------------------------------------------------------------------
     |

--- a/src/Layout/Asset.php
+++ b/src/Layout/Asset.php
@@ -689,7 +689,13 @@ class Asset
             $url .= '?';
         }
 
-        $ver = 'v'.Admin::VERSION;
+        $assetsVersion = config('admin.assets_version', Admin::VERSION);
+
+        if (! $assetsVersion) {
+            return rtrim($url, '?');
+        }
+
+        $ver = 'v'.$assetsVersion;
 
         return Str::endsWith($url, '?') ? $url.$ver : $url.'&'.$ver;
     }


### PR DESCRIPTION
## 背景

原有实现中，JS/CSS URL 的缓存破坏版本参数（`?v2.3.10-beta`）强制使用框架版本号（`Admin::VERSION`），用户无法单独控制，导致升级框架时才能让浏览器重新加载资源，反之亦然。

相关上游 issue：[jqhph/dcat-admin#2177](https://github.com/jqhph/dcat-admin/issues/2177)

## 改动

- **`src/Layout/Asset.php`** — `withVersionQuery()` 优先读取 `config('admin.assets_version')`，为空时 fallback 到 `Admin::VERSION`；值为空字符串/`null` 时不附加任何版本查询参数
- **`config/admin.php`** — 新增 `assets_version` 配置项，支持 `ADMIN_ASSETS_VERSION` 环境变量
- **`src/Console/stubs/config.stub`** — 同步更新 stub，新安装项目自动带上该配置
- **`README.md`** — 在新增功能列表中注明此特性

## 使用方式

在 `.env` 中设置：

```
ADMIN_ASSETS_VERSION=1.0.0
```

或在 `config/admin.php` 中直接写值。留空（默认）则沿用框架版本号；显式设为空字符串则不添加任何版本查询参数。